### PR TITLE
fix: 채팅, 친구관리 피드백 적용

### DIFF
--- a/FE/css/ChattingPage/friendList.css
+++ b/FE/css/ChattingPage/friendList.css
@@ -1,13 +1,14 @@
-.FriendListContainer {
+.chatContainer .FriendListContainer {
 	padding: 2.5%;
 	box-sizing: border-box;
 	overflow-y: scroll;
+	background-color: rgb(2, 4, 31);
 }
-.FriendListContainer::-webkit-scrollbar {
+.chatContainer .FriendListContainer::-webkit-scrollbar {
 	display: none;
 }
 
-.friendItem {
+.chatContainer .friendItem {
 	position: relative;
 	display: flex;
 	flex-direction: row;
@@ -20,24 +21,24 @@
 	color: white;
 	margin: 1% 0;
 }
-.friendItem:hover {
+.chatContainer .friendItem:hover {
 	background-color: rgb(213, 112, 255);
 	color: rgb(2, 4, 31);
 	transition: 0.3s;
 	cursor: pointer;
 }
-.selectedFriendItem {
+.chatContainer .selectedFriendItem {
 	background-color: rgb(213, 112, 255);
 	color: rgb(2, 4, 31);
 }
 
-.avatarContainer {
+.chatContainer .avatarContainer {
 	position: relative;
 	width: 23%;
 	aspect-ratio: 1/1;
 	margin: 0 8% 0 6%;
 }
-.avatarImgFrame {
+.chatContainer .avatarImgFrame {
 	height: 100%;
 	width: 100%;
 	border-radius: 15rem;
@@ -46,10 +47,10 @@
 	background: linear-gradient(to bottom, rgb(50, 26, 81), rgb(2, 4, 31));
 	overflow: hidden;
 }
-.avatarImg {
+.chatContainer .avatarImg {
 	width: 100%;
 }
-.activeState {
+.chatContainer .activeState {
 	position: absolute;
 	bottom: 4%;
 	right: 0%;
@@ -59,7 +60,7 @@
 	border-radius: 10rem;
 }
 
-.infoBox {
+.chatContainer .infoBox {
 	height: 50%;
 	width: 55%;
 	display: flex;
@@ -67,7 +68,7 @@
 	justify-content: space-between;
 	align-items: flex-start;
 }
-.nickname {
+.chatContainer .nickname {
 	width: 100%;
 	font-size: 1.6rem;
 	font-weight: 800;
@@ -76,7 +77,7 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
-.recentMessage {
+.chatContainer .recentMessage {
 	width: 67%;
 	font-size: 1.1rem;
 	font-weight: 400;
@@ -86,7 +87,7 @@
 	overflow: hidden;
 }
 
-.inviteButton {
+.chatContainer .inviteButton {
 	position: absolute;
 	right: 5%;
 	bottom: 15%;
@@ -102,7 +103,7 @@
 	justify-content: center;
 	align-items: center;
 }
-.disabledInviteButton {
+.chatContainer .disabledInviteButton {
 	background-color: rgb(190, 190, 190);
 	color: rgb(130, 130, 130);
 }

--- a/FE/css/LoginPage/loginPage.css
+++ b/FE/css/LoginPage/loginPage.css
@@ -82,6 +82,9 @@ form {
 	font-size: 1.4rem;
 	font-weight: 300;
 }
+#signupButton:hover {
+	color: rgba(255, 255, 255, 0.7);
+}
 
 @media (orientation: landscape) and (max-aspect-ratio: 1.5/1) {
 	#container {

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -222,7 +222,7 @@ class ChattingPageManager {
 		if (this.readingFriendId) {
 			await this._sendStopReadingMessage();
 		}
-		this.clientInfo.socket.removeEventListener('message', this._messageArriveListener);
+		this.clientInfo.socket.removeEventListener("message", this._messageArriveListener);
 	}
 
 	_getSortedFriendList() {
@@ -233,18 +233,25 @@ class ChattingPageManager {
 	}
 
 	_setInputButton() {
-		this.inputBox = document.querySelector(".inputBox");
-		document.querySelector(".inputButton").addEventListener("click", () => {
+		const sendMessage = () => {
 			if (this.inputBox.value === "") return;
 			const sendMessage = {
 				event: "sendMessage",
 				content: {
 					clientId: this.readingFriendId,
-					message: this.inputBox.value
-				}
-			}
+					message: this.inputBox.value,
+				},
+			};
 			this.clientInfo.socket.send(JSON.stringify(sendMessage));
 			this.inputBox.value = "";
+		};
+		this.inputBox = document.querySelector(".inputBox");
+		document.querySelector(".inputButton").addEventListener("click", sendMessage);
+		this.inputBox.addEventListener("keydown", e => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				sendMessage();
+			}
 		});
 	}
 
@@ -276,15 +283,15 @@ class ChattingPageManager {
 		};
 		this.readingFriendId = null;
 		this.clientInfo.socket.send(JSON.stringify(stopReadingChatMessage));
-		await new Promise((resolve) => {
-			const listener = (messageEvent) => {
+		await new Promise(resolve => {
+			const listener = messageEvent => {
 				const { event, content } = JSON.parse(messageEvent.data);
-				if (event === 'stopReadingChatResponse' && content.message === 'OK') {
-					this.clientInfo.socket.removeEventListener('message', listener);
+				if (event === "stopReadingChatResponse" && content.message === "OK") {
+					this.clientInfo.socket.removeEventListener("message", listener);
 					resolve();
 				}
-			}
-			this.clientInfo.socket.addEventListener('message', listener);
+			};
+			this.clientInfo.socket.addEventListener("message", listener);
 		});
 	}
 
@@ -315,19 +322,19 @@ class ChattingPageManager {
 		const getTotalChatDataMessage = {
 			event: "getTotalChatData",
 			content: {
-				clientId: id
-			}
-		}
+				clientId: id,
+			},
+		};
 		this.clientInfo.socket.send(JSON.stringify(getTotalChatDataMessage));
-		const messageList = await new Promise((resolve) => {
-			const listener = (messageEvent) => {
+		const messageList = await new Promise(resolve => {
+			const listener = messageEvent => {
 				const { event, content } = JSON.parse(messageEvent.data);
-				if (event === 'getTotalChatDataResponse') {
-					this.clientInfo.socket.removeEventListener('message', listener);
+				if (event === "getTotalChatDataResponse") {
+					this.clientInfo.socket.removeEventListener("message", listener);
 					resolve(content.messageList);
 				}
-			}
-			this.clientInfo.socket.addEventListener('message', listener);
+			};
+			this.clientInfo.socket.addEventListener("message", listener);
 		});
 
 		this.readingFriendId = id;

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -18,12 +18,12 @@ class ChattingPageManager {
 
 		document.body.appendChild(button);
 		this._renderTotalUnreadMessageCount();
-		this.clientInfo.socket.addEventListener('message', (messageEvent) => {
+		this.clientInfo.socket.addEventListener("message", messageEvent => {
 			const { event, content } = JSON.parse(messageEvent.data);
-			if (event === 'notifyMessageArrive') {
+			if (event === "notifyMessageArrive") {
 				this._renderTotalUnreadMessageCount();
 			}
-		})
+		});
 	}
 	_renderTotalUnreadMessageCount() {
 		const count = this.clientInfo.friendInfo.friendList.reduce((acc, current) => {
@@ -95,28 +95,19 @@ class ChattingPageManager {
 		window.addEventListener("click", this.noFriendContainerWindowClickListener);
 
 		// 친구가 새로 생긴경우
-		this.noFriendAndGetFriendListener = (messageEvent) => {
+		this.noFriendAndGetFriendListener = messageEvent => {
 			const { event, content } = JSON.parse(messageEvent.data);
-			if (
-				(event === 'acceptFriendRequestResponse' && content.message === 'OK') ||
-				event === 'notifyFriendRequestAccepted'
-			) {
+			if ((event === "acceptFriendRequestResponse" && content.message === "OK") || event === "notifyFriendRequestAccepted") {
 				this._closeNoFriendChatContainer();
 				this._openChatContainer();
 			}
 		};
-		this.clientInfo.socket.addEventListener(
-			'message',
-			this.noFriendAndGetFriendListener
-		);
+		this.clientInfo.socket.addEventListener("message", this.noFriendAndGetFriendListener);
 	}
 
 	_closeNoFriendChatContainer() {
 		window.removeEventListener("click", this.noFriendContainerWindowClickListener);
-		this.clientInfo.socket.removeEventListener(
-			'message',
-			this.noFriendAndGetFriendListener
-		);
+		this.clientInfo.socket.removeEventListener("message", this.noFriendAndGetFriendListener);
 		this._noFriendContainerOpened = false;
 		this.noFriendContainer.remove();
 		this.noFriendContainer = null;
@@ -246,7 +237,17 @@ class ChattingPageManager {
 	// }
 
 	_renderFriendList() {
-		document.querySelector(".FriendListContainer").innerHTML = this._getFriendListHTML();
+		const friendListContainer = document.querySelector(".FriendListContainer");
+		friendListContainer.innerHTML = this._getFriendListHTML();
+		friendListContainer.querySelectorAll(".friendItem").forEach((friendItem)=>{
+			const id = friendItem.dataset.id;
+			console.log(id);
+			console.log(friendItem.querySelector(".avatarImg"));
+			friendItem.querySelector(".avatarImg").addEventListener("click", (e)=>{
+				e.stopPropagation();
+				alert(`ID는 ${id}다`);
+			})
+		})
 		const friendItems = Array.from(document.querySelectorAll(".friendItem"));
 		const readingItem = friendItems.find(item => {
 			return parseInt(item.dataset.id) === this.readingFriendId;
@@ -340,7 +341,6 @@ class ChattingPageManager {
 	}
 	_getFriendListHTML() {
 		const getFriendItemHTML = function (friend) {
-			console.log(friend);
 			return `
                 <button class="friendItem" data-id="${friend.id}">
                     <div class="avatarContainer">
@@ -351,7 +351,7 @@ class ChattingPageManager {
                     </div>
                     <div class="infoBox">
                         <div class="nickname">${friend.nickname}</div>
-                        <div class="recentMessage">${friend.chat?.recentMessage?friend.chat.recentMessage:"아직 대화를 나누지 않은 친구입니다."}</div>
+                        <div class="recentMessage">${friend.chat?.recentMessage ? friend.chat.recentMessage : "아직 대화를 나누지 않은 친구입니다."}</div>
                     </div>
                     <div class="inviteButton invisible ${friend.activeState === "ACTIVE" ? "" : "disabledInviteButton"}">초대</div>
 					<div class="unreadCount ${!friend.chat?.unreadMessageCount ? "invisible" : ""}">${getUnreadCount(friend)}</div>

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -360,22 +360,10 @@ class ChattingPageManager {
 			this._renderTotalUnreadMessageCount();
 		}
 
-		// const messageList = [
-		// 	{ senderId: 1, content: "오늘 한 판 고고?" },
-		// 	{ senderId: 2, content: "너 개못하잖아" },
-		// 	{ senderId: 1, content: "까부네 ㅋㅋ" },
-		// 	{ senderId: 2, content: "드루와라" },
-		// 	{
-		// 		senderId: 2,
-		// 		content:
-		// 			"늘 저녁 뭐 먹을까? 치킨이 땡기는데, 네 생각은 어때? 우리 동네에 새로 생긴 치킨집이 있다던데, 거기 한번 가볼까? 맛있다는 평이 많아서 기대돼. 어떤 메뉴 먹고 싶어? 양념치킨? 후라이드치킨? 아니면 반반치킨? 나는 반반치킨이 좋아. 다양한 맛을 즐길 수 있어서 좋아. 7시에 만나서 같이 먹자. 너도 그때까지 배고프지 않게 간단한 간식 먹고 있어. 그럼 이따 보자!",
-		// 	},
-		// ];
-
 		const messageListHTML = messageList.reduce((acc, message) => {
 			const senderSide = message.senderId === this.clientInfo.id ? "rightSender" : "leftSender";
 			const messageHTML = `<div class="messageBubble ${senderSide}">${message.content}</div>`;
-			return acc + messageHTML;
+			return messageHTML + acc;
 		}, "");
 		this.messageListContainer.innerHTML = messageListHTML;
 		this.messageListContainer.scrollTop = this.messageListContainer.scrollHeight;

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -234,21 +234,36 @@ class ChattingPageManager {
 
 	_setInputButton() {
 		const sendMessage = () => {
-			if (this.inputBox.value === "") return;
-			const sendMessage = {
+			const messageContent = this.inputBox.value.trim();
+			if (messageContent === "") return;
+			const sendMessageObj = {
 				event: "sendMessage",
 				content: {
 					clientId: this.readingFriendId,
-					message: this.inputBox.value,
+					message: messageContent,
 				},
 			};
-			this.clientInfo.socket.send(JSON.stringify(sendMessage));
+			this.clientInfo.socket.send(JSON.stringify(sendMessageObj));
 			this.inputBox.value = "";
 		};
+
 		this.inputBox = document.querySelector(".inputBox");
-		document.querySelector(".inputButton").addEventListener("click", sendMessage);
+		const inputButton = document.querySelector(".inputButton");
+
+		inputButton.addEventListener("click", sendMessage);
+
+		let isComposing = false;
+
+		this.inputBox.addEventListener("compositionstart", () => {
+			isComposing = true;
+		});
+
+		this.inputBox.addEventListener("compositionend", () => {
+			isComposing = false;
+		});
+
 		this.inputBox.addEventListener("keydown", e => {
-			if (e.key === "Enter") {
+			if (e.key === "Enter" && !isComposing) {
 				e.preventDefault();
 				sendMessage();
 			}

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -20,8 +20,10 @@ class ChattingPageManager {
 		this._renderTotalUnreadMessageCount();
 		this.clientInfo.socket.addEventListener("message", messageEvent => {
 			const { event, content } = JSON.parse(messageEvent.data);
-			if (event === "notifyMessageArrive") {
-				this._renderTotalUnreadMessageCount();
+			if (event === "notifyMessageArrive" || event === "notifyFriendDeleted" || event === "deleteFriendResponse") {
+				setTimeout(() => {
+					this._renderTotalUnreadMessageCount();
+				}, 0);
 			}
 		});
 	}
@@ -239,15 +241,15 @@ class ChattingPageManager {
 	_renderFriendList() {
 		const friendListContainer = document.querySelector(".FriendListContainer");
 		friendListContainer.innerHTML = this._getFriendListHTML();
-		friendListContainer.querySelectorAll(".friendItem").forEach((friendItem)=>{
+		friendListContainer.querySelectorAll(".friendItem").forEach(friendItem => {
 			const id = friendItem.dataset.id;
 			console.log(id);
 			console.log(friendItem.querySelector(".avatarImg"));
-			friendItem.querySelector(".avatarImg").addEventListener("click", (e)=>{
+			friendItem.querySelector(".avatarImg").addEventListener("click", e => {
 				e.stopPropagation();
 				alert(`ID는 ${id}다`);
-			})
-		})
+			});
+		});
 		const friendItems = Array.from(document.querySelectorAll(".friendItem"));
 		const readingItem = friendItems.find(item => {
 			return parseInt(item.dataset.id) === this.readingFriendId;
@@ -329,7 +331,6 @@ class ChattingPageManager {
 			event === "notifyFriendActiveStateChange"
 		) {
 			this._renderFriendList();
-			this._renderTotalUnreadMessageCount();
 		}
 	};
 

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -351,7 +351,7 @@ class ChattingPageManager {
                     </div>
                     <div class="infoBox">
                         <div class="nickname">${friend.nickname}</div>
-                        <div class="recentMessage">${friend.chat?.recentMessage ? friend.chat.recentMessage : "아직 대화를 나누지 않은 친구입니다."}</div>
+                        <div class="recentMessage">${friend.chat?.recentMessage ? friend.chat.recentMessage : ""}</div>
                     </div>
                     <div class="inviteButton invisible ${friend.activeState === "ACTIVE" ? "" : "disabledInviteButton"}">초대</div>
 					<div class="unreadCount ${!friend.chat?.unreadMessageCount ? "invisible" : ""}">${getUnreadCount(friend)}</div>

--- a/FE/js/ChattingPage/chattingPageManager.js
+++ b/FE/js/ChattingPage/chattingPageManager.js
@@ -3,82 +3,6 @@ class ChattingPageManager {
 		console.log("Chatting Page!");
 
 		this.clientInfo = clientInfo;
-		//추후 삭제해야함
-		// this.clientInfo = {
-		// 	id: 1,
-		// 	friendInfo: {},
-		// };
-		// TODO : 임시 하드코딩
-		// this.clientInfo.friendInfo.friendList = [
-		// 	{
-		// 		id: 1,
-		// 		nickname: "조뱀파이어어어어어어",
-		// 		avatarUrl: "images/playerA.png",
-		// 		activeState: "ACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 1,
-		// 		},
-		// 	},
-		// 	{
-		// 		id: 2,
-		// 		nickname: "박뱀파이어",
-		// 		avatarUrl: "images/humanIcon.png",
-		// 		activeState: "ACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 3,
-		// 		},
-		// 	},
-		// 	{
-		// 		id: 3,
-		// 		nickname: "이뱀파이어",
-		// 		avatarUrl: "images/playerB.png",
-		// 		activeState: "INACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 0,
-		// 		},
-		// 	},
-		// 	{
-		// 		id: 4,
-		// 		nickname: "김뱀파이어",
-		// 		avatarUrl: "images/playerA.png",
-		// 		activeState: "ACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 2,
-		// 		},
-		// 	},
-		// 	{
-		// 		id: 5,
-		// 		nickname: "최뱀파이어",
-		// 		avatarUrl: "images/playerA.png",
-		// 		activeState: "ACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 0,
-		// 		},
-		// 	},
-		// 	{
-		// 		id: 6,
-		// 		nickname: "정뱀파이어",
-		// 		avatarUrl: "images/playerA.png",
-		// 		activeState: "INACTIVE",
-		// 		chat: {
-		// 			recentMessage: "하이하이하이하이하이하이하이하이",
-		// 			recentTimestamp: "2024-07-02T14:30:00Z",
-		// 			unreadMessageCount: 1000,
-		// 		},
-		// 	},
-		// ];
-		//친구 없는 경우
-		// this.clientInfo.friendInfo.friendList = []
 		this._appendChatButton();
 
 		this._initPage();
@@ -94,15 +18,14 @@ class ChattingPageManager {
 
 		document.body.appendChild(button);
 		this._renderTotalUnreadMessageCount();
-		// this.clientInfo.socket.addEventListener('message', (messageEvent) => {
-		// 	const { event, content } = JSON.parse(messageEvent.data);
-		// 	if (event === 'notifyMessageArrive') {
-		// 		this._renderTotalUnreadMessageCount();
-		// 	}
-		// })
+		this.clientInfo.socket.addEventListener('message', (messageEvent) => {
+			const { event, content } = JSON.parse(messageEvent.data);
+			if (event === 'notifyMessageArrive') {
+				this._renderTotalUnreadMessageCount();
+			}
+		})
 	}
 	_renderTotalUnreadMessageCount() {
-		console.log(this.clientInfo);
 		const count = this.clientInfo.friendInfo.friendList.reduce((acc, current) => {
 			return acc + current.chat.unreadMessageCount;
 		}, 0);
@@ -172,28 +95,28 @@ class ChattingPageManager {
 		window.addEventListener("click", this.noFriendContainerWindowClickListener);
 
 		// 친구가 새로 생긴경우
-		// this.noFriendAndGetFriendListener = (messageEvent) => {
-		// 	const { event, content } = JSON.parse(messageEvent.data);
-		// 	if (
-		// 		(event === 'acceptFriendRequestResponse' && content.message === 'OK') ||
-		// 		event === 'notifyFriendRequestAccepted'
-		// 	) {
-		// 		this._closeNoFriendChatContainer();
-		// 		this._openChatContainer();
-		// 	}
-		// };
-		// this.clientInfo.socket.addEventListener(
-		// 	'message',
-		// 	this.noFriendAndGetFriendListener
-		// );
+		this.noFriendAndGetFriendListener = (messageEvent) => {
+			const { event, content } = JSON.parse(messageEvent.data);
+			if (
+				(event === 'acceptFriendRequestResponse' && content.message === 'OK') ||
+				event === 'notifyFriendRequestAccepted'
+			) {
+				this._closeNoFriendChatContainer();
+				this._openChatContainer();
+			}
+		};
+		this.clientInfo.socket.addEventListener(
+			'message',
+			this.noFriendAndGetFriendListener
+		);
 	}
 
 	_closeNoFriendChatContainer() {
 		window.removeEventListener("click", this.noFriendContainerWindowClickListener);
-		// this.clientInfo.socket.removeEventListener(
-		// 	'message',
-		// 	this.noFriendAndGetFriendListener
-		// );
+		this.clientInfo.socket.removeEventListener(
+			'message',
+			this.noFriendAndGetFriendListener
+		);
 		this._noFriendContainerOpened = false;
 		this.noFriendContainer.remove();
 		this.noFriendContainer = null;
@@ -283,7 +206,7 @@ class ChattingPageManager {
 				if (this.readingFriendId) {
 					await this._sendStopReadingMessage();
 				}
-				this._setSelectedFriendItem(item);
+				// this._setSelectedFriendItem(item);
 				this._renderEntireMessage(parseInt(item.dataset.id));
 			});
 		});
@@ -311,16 +234,16 @@ class ChattingPageManager {
 	}
 
 	// TODO : 대기실 페이지일 때만 초대 버튼 표시하기
-	_setSelectedFriendItem(friendItem) {
-		// if (this.selectedFriendItem) {
-		// 	this.selectedFriendItem.classList.remove("selectedFriendItem");
-		// 	this.selectedInviteButton.classList.add("invisible");
-		// }
-		// this.selectedFriendItem = friendItem;
-		// this.selectedInviteButton = friendItem.querySelector(".inviteButton");
-		// this.selectedFriendItem.classList.add("selectedFriendItem");
-		// this.selectedInviteButton.classList.remove("invisible");
-	}
+	// _setSelectedFriendItem(friendItem) {
+	// 	if (this.selectedFriendItem) {
+	// 		this.selectedFriendItem.classList.remove("selectedFriendItem");
+	// 		this.selectedInviteButton.classList.add("invisible");
+	// 	}
+	// 	this.selectedFriendItem = friendItem;
+	// 	this.selectedInviteButton = friendItem.querySelector(".inviteButton");
+	// 	this.selectedFriendItem.classList.add("selectedFriendItem");
+	// 	this.selectedInviteButton.classList.remove("invisible");
+	// }
 
 	_renderFriendList() {
 		document.querySelector(".FriendListContainer").innerHTML = this._getFriendListHTML();
@@ -328,7 +251,7 @@ class ChattingPageManager {
 		const readingItem = friendItems.find(item => {
 			return parseInt(item.dataset.id) === this.readingFriendId;
 		});
-		this._setSelectedFriendItem(readingItem);
+		// this._setSelectedFriendItem(readingItem);
 		this._setFriendItems();
 	}
 
@@ -417,6 +340,7 @@ class ChattingPageManager {
 	}
 	_getFriendListHTML() {
 		const getFriendItemHTML = function (friend) {
+			console.log(friend);
 			return `
                 <button class="friendItem" data-id="${friend.id}">
                     <div class="avatarContainer">
@@ -427,10 +351,10 @@ class ChattingPageManager {
                     </div>
                     <div class="infoBox">
                         <div class="nickname">${friend.nickname}</div>
-                        <div class="recentMessage">${friend.chat.recentMessage}</div>
+                        <div class="recentMessage">${friend.chat?.recentMessage?friend.chat.recentMessage:"아직 대화를 나누지 않은 친구입니다."}</div>
                     </div>
                     <div class="inviteButton invisible ${friend.activeState === "ACTIVE" ? "" : "disabledInviteButton"}">초대</div>
-					<div class="unreadCount ${friend.chat.unreadMessageCount === 0 ? "invisible" : ""}">${getUnreadCount(friend)}</div>
+					<div class="unreadCount ${!friend.chat?.unreadMessageCount ? "invisible" : ""}">${getUnreadCount(friend)}</div>
                 </button>
             `;
 		};

--- a/FE/js/FriendManagementPage/FriendManagementPageManager.js
+++ b/FE/js/FriendManagementPage/FriendManagementPageManager.js
@@ -270,6 +270,10 @@ class FriendManagementPageManager {
 		const newFriendClient = this.clientInfo.friendInfo.clientListWhoFriendRequestedMe.find(client => client.id === id);
 		if (newFriendClient) {
 			this.clientInfo.friendInfo.clientListWhoFriendRequestedMe = this.clientInfo.friendInfo.clientListWhoFriendRequestedMe.filter(client => client.id !== newFriendClient.id);
+			newFriendClient.chat = {
+				recentTimestamp: null,
+				unreadMessageCount: 0
+			}
 			this.clientInfo.friendInfo.friendList.push(newFriendClient);
 			this._renderTabByCurrentMode();
 		}

--- a/FE/js/LoginPage/LoginPageManager.js
+++ b/FE/js/LoginPage/LoginPageManager.js
@@ -218,7 +218,10 @@ class LoginPageManager {
 				const acceptedClient = this.clientInfo.friendInfo.clientListIFriendRequested.find(client => client.id === content.clientInfo.id);
 				if (acceptedClient) {
 					this.clientInfo.friendInfo.clientListIFriendRequested = this.clientInfo.friendInfo.clientListIFriendRequested.filter(client => client.id !== content.clientInfo.id);
-
+					acceptedClient.chat = {
+						recentTimestamp: null,
+						unreadMessageCount: 0
+					}
 					this.clientInfo.friendInfo.friendList.push(acceptedClient);
 				}
 			} else if (event === "notifyFriendRequestRejected") {

--- a/FE/js/LoginPage/LoginPageManager.js
+++ b/FE/js/LoginPage/LoginPageManager.js
@@ -57,7 +57,7 @@ class LoginPageManager {
 
 			this.onLoginSuccess();
 		} catch (error) {
-			this.warning.textContent = "아이디 또는 비밀번호가 올바르지 않습니다.";
+			this.warning.textContent = error.message;
 		}
 	}
 
@@ -67,24 +67,29 @@ class LoginPageManager {
 			password: pw,
 		};
 		const url = `http://${SERVER_ADDRESS}:${SERVER_PORT}/login`;
+		let response;
 		try {
-			const response = await fetch(url, {
+			response = await fetch(url, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify(userData),
 			});
-			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
-			}
-			const bearerAccessToken = response.headers.get("Authorization");
-			const accessToken = bearerAccessToken.replace("Bearer ", "");
-			if (!accessToken) throw new Error("No AccessToken");
-			this.accessToken = accessToken;
 		} catch (error) {
-			throw error;
+			throw new Error('서버의 응답이 없습니다.');
 		}
+		if (!response.ok) {
+			if (400 <= response.status && response.status < 500) {
+				throw new Error('아이디 또는 비밀번호가 올바르지 않습니다.');
+			} else if (500 <= response.status) {
+				throw new Error('서버와의 연결이 불안정합니다.');
+			}
+		}
+		const bearerAccessToken = response.headers.get("Authorization");
+		const accessToken = bearerAccessToken.replace("Bearer ", "");
+		if (!accessToken) throw new Error('서버와의 연결이 불안정합니다.');
+		this.accessToken = accessToken;
 	}
 
 	async _connectGlobalSocket(id) {

--- a/FE/js/SignupPage/SignupPageManager.js
+++ b/FE/js/SignupPage/SignupPageManager.js
@@ -26,6 +26,7 @@ class SignupPageManager {
 		this.pwInput = document.querySelector("#pwInput");
 		this.pwInput.addEventListener("input", () => {
 			this._checkPw();
+			this._checkRePw();
 			this._updateSignupButton();
 		});
 		this.rePwInput = document.querySelector("#rePwInput");
@@ -50,22 +51,40 @@ class SignupPageManager {
 	}
 
 	_checkId = async () => {
+		if (this.idInput.value === '') {
+			this.idWarning.textContent = '';
+			this.idValidState = false;
+			return;
+		}
 		if (!this._validateId(this.idInput.value)) {
 			const invalidIdMessage = "1에서 20자의 영문, 숫자만 사용 가능합니다.";
 			this.idWarning.textContent = invalidIdMessage;
 			this.idValidState = false;
 			return;
 		}
-		if (!(await this._validateDuplicateId(this.idInput.value))) {
-			const duplicateIdMessage = "이미 존재하는 아이디입니다.";
-			this.idWarning.textContent = duplicateIdMessage;
-			this.idValidState = false;
+		try {
+			if (!(await this._validateDuplicateId(this.idInput.value))) {
+				const duplicateIdMessage = "이미 존재하는 아이디입니다.";
+				this.idWarning.textContent = duplicateIdMessage;
+				this.idValidState = false;
+				return;
+			}
+		} catch (error) {
+			if (error instanceof Error)
+				this.idWarning.textContent = error.message;
+			if (error instanceof TypeError && error.message === 'Failed to fetch')
+				this.idWarning.textContent = "서버의 응답이 없습니다.";
 			return;
 		}
 		this.idValidState = true;
 		this.idWarning.textContent = "";
 	};
 	_checkPw = () => {
+		if (this.pwInput.value === '') {
+			this.pwWarning.textContent = '';
+			this.pwValidState = false;
+			return;
+		}
 		if (!this._validatePw(this.pwInput.value)) {
 			const invalidPwMessage = "8에서 20자로 영문, 숫자, 특수문자를 모두 포함해야 합니다.";
 			this.pwWarning.textContent = invalidPwMessage;
@@ -76,6 +95,11 @@ class SignupPageManager {
 		this.pwWarning.textContent = "";
 	};
 	_checkRePw = () => {
+		if (this.rePwInput.value === '') {
+			this.rePwWarning.textContent = '';
+			this.rePwValidState = false;
+			return;
+		}
 		if (!this._validateRePw(this.pwInput.value, this.rePwInput.value)) {
 			const invalidRePwMessage = "비밀번호와 일치하지 않습니다.";
 			this.rePwWarning.textContent = invalidRePwMessage;
@@ -86,16 +110,29 @@ class SignupPageManager {
 		this.rePwWarning.textContent = "";
 	};
 	_checkNickName = async () => {
+		if (this.nickNameInput.value === '') {
+			this.nickNameWarning.textContent = '';
+			this.nickNameValidState = false;
+			return;
+		}
 		if (!this._validateNickName(this.nickNameInput.value)) {
 			const invalidNickNameMessage = "1에서 20자의 영문, 숫자, 한글만 사용 가능합니다.";
 			this.nickNameWarning.textContent = invalidNickNameMessage;
 			this.nickNameValidState = false;
 			return;
 		}
-		if (!(await this._validateDuplicateNickName(this.nickNameInput.value))) {
-			const duplicateNickNameMessage = "이미 존재하는 닉네임입니다.";
-			this.nickNameWarning.textContent = duplicateNickNameMessage;
-			this.nickNameValidState = false;
+		try {
+			if (!(await this._validateDuplicateNickName(this.nickNameInput.value))) {
+				const duplicateNickNameMessage = "이미 존재하는 닉네임입니다.";
+				this.nickNameWarning.textContent = duplicateNickNameMessage;
+				this.nickNameValidState = false;
+				return;
+			}
+		} catch (error) {
+			if (error instanceof Error)
+				this.nickNameWarning.textContent = error.message;
+			if (error instanceof TypeError && error.message === 'Failed to fetch')
+				this.nickNameWarning.textContent = "서버의 응답이 없습니다.";
 			return;
 		}
 		this.nickNameValidState = true;
@@ -105,41 +142,33 @@ class SignupPageManager {
 	async _validateDuplicateId(id) {
 		const query = new URLSearchParams({ username: id }).toString();
 		const url = `http://${SERVER}:${PORT}/check-username?${query}`;
-		try {
-			const response = await fetch(url, {
-				method: "GET",
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
-			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
-			}
-			const data = await response.json();
-			return data.is_available;
-		} catch (error) {
-			console.error("Error:", error);
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		if (!response.ok) {
+			throw new Error('서버와의 연결이 불안정합니다.');
 		}
+		const data = await response.json();
+		return data.is_available;
 	}
 
 	async _validateDuplicateNickName(nickName) {
 		const query = new URLSearchParams({ nickname: nickName }).toString();
 		const url = `http://${SERVER}:${PORT}/check-nickname?${query}`;
-		try {
-			const response = await fetch(url, {
-				method: "GET",
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
-			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
-			}
-			const data = await response.json();
-			return data.is_available;
-		} catch (error) {
-			console.error("Error:", error);
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		if (!response.ok) {
+			throw new Error('서버와의 연결이 불안정합니다.');
 		}
+		const data = await response.json();
+		return data.is_available;
 	}
 
 	_validateId(id) {
@@ -184,18 +213,47 @@ class SignupPageManager {
 			});
 
 			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
+				let information = '';
+				if (response.status === 409) {
+					const responseData = await response.json(); 
+					if (responseData.duplicated_item === 'id') {
+						information = '이미 존재하는 아이디입니다.';
+					} else if (responseData.duplicated_item === 'nickname') {
+						information = '이미 존재하는 닉네임입니다.';
+					}
+				} else if (response.status >= 400 && response.status < 500) {
+					information = '입력 내용이 유효하지 않습니다.';
+				} else if (response.status >= 500) {
+					information = '서버와의 연결이 불안정합니다.';
+				}
+				throw new Error(information);
 			}
 
-			// const data = await response.json();
-			// console.log('회원가입 성공:', data);
-			// 회원가입 성공 후 추가 작업 (예: 리디렉션)
-			this.onSignupSuccess();
 		} catch (error) {
-			console.error("회원가입 실패:", error);
+			if (error instanceof Error)
+				this._displaySignupFailureNotiWindow(error.message);
+			if (error instanceof TypeError && error.message === 'Failed to fetch')
+				this._displaySignupFailureNotiWindow("서버의 응답이 없습니다.");
 		}
+
+
+		// const data = await response.json();
+		// console.log('회원가입 성공:', data);
+		// 회원가입 성공 후 추가 작업 (예: 리디렉션)
 		this.onSignupSuccess();
 	};
+	_displaySignupFailureNotiWindow(infomation) {
+		const notiWindow = document.querySelector('.notiWindow');
+		notiWindow.querySelector('.infomation').textContent = infomation;
+		notiWindow.style.display = 'flex';
+
+		const confirmButton = notiWindow.querySelector('.confirmButton');
+		const listener = () => {
+			confirmButton.removeEventListener('click', listener);
+			notiWindow.style.display = 'none';
+		}
+		confirmButton.addEventListener('click', listener);
+	}
 
 	_updateSignupButton = () => {
 		if (this.idValidState && this.pwValidState && this.rePwValidState && this.nickNameValidState) {
@@ -226,6 +284,7 @@ class SignupPageManager {
 				</div>
 			</div>
 			<button id="signupButton" class="disabledButton">회원가입</button>
+			${this._getSignupFailureNotiWindowHTML()}
 		`;
 	}
 	_getIdContainerHTML() {
@@ -255,6 +314,15 @@ class SignupPageManager {
 			<label class="label" for="nickNameInput">닉네임</label>
 			<input class="input" type="text" id="nickNameInput">
 			<div class="warning" id="nickNameWarning"></div>
+		`;
+	}
+
+	_getSignupFailureNotiWindowHTML() {
+		return `
+			<div class="notiWindow">
+				<div class="infomation">이미 존재하는 아이디입니다.</div>
+				<button class="confirmButton">확인</button>
+			</div>
 		`;
 	}
 }

--- a/fe/css/common.css
+++ b/fe/css/common.css
@@ -185,6 +185,43 @@ body {
 	padding: 2.5% 2.5%;
 }
 
+.notiWindow {
+	display: none;
+	/* display: flex; */
+	position: absolute;
+	z-index: 1;
+	width: 20%;
+	aspect-ratio: 2/1;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	background-color: white;
+	color: rgb(1, 4, 37);
+	border-radius: 1rem;
+}
+.infomation {
+	font-size: 1.6rem;
+	font-weight: 600;
+	padding-bottom: 20%;
+}
+.confirmButton {
+	position: absolute;
+	bottom: 10%;
+	left: 5%;
+	right: 5%;
+	aspect-ratio: 5.5/1;
+	background-color: rgb(1, 4, 37);
+	color: white;
+	font-size: 1.4rem;
+	font-weight: 500;
+	border-radius: 1rem;
+}
+.confirmButton:hover {
+	background-color: rgb(213, 112, 255);
+	color: rgb(1, 4, 37);
+	font-weight: 700;
+}
+
 @media (orientation: portrait) {
 	.exitButton {
 		top: 2%;


### PR DESCRIPTION
- 로그인
    - [x]  서버와 통신이 원할하지 않을 경우 `아이디 또는 비밀번호가 올바르지 않습니다.` 가 아닌 다른 메시지 띄우기
    - [x]  회원가입 버튼 누를 때, 호버됐다는 걸 알려줄 수 있으면 좋을 듯
- 회원가입
    - [x]  아이디/닉네임 중복검사에서 서버와 통신이 원할하지 않을 경우 `이미 존재하는 아이디입니다.` 가 아닌 다른 메시지 띄우기
    - [x]  회원가입 실패(중복된 아이디, 닉네임) 상황 고려하기
    - [x]  비밀번호 재입력 칸이 비어있는 경우에 회원가입 버튼이 활성화될 때가 있음
    - [x]  입력란에서 모든 텍스트를 지웠을 경우, 경고 텍스트 띄우지 않기
    - [ ]  ~~입력란에 무언가를 입력해야만 조건을 볼 수 있다는 게 불편함~~
    - [ ]  ~~회원가입 완료 후 로그인 창으로 넘어오는 게 부자연스러운 것 같기도 하고..~~

- 채팅
    - [x]  채팅 인터페이스를 통해 다른 플레이어의 프로필에 접근할 수 있어야 한다.
        - ~~임시 페이지를 만들고 연결시켜놓기~~
    - [x]  채팅을 엔터로 칠 수 없다.
    - [x]  다시 로그인 하면 채팅이 역순으로 나옴
    - [x]  친구 목록을 timeStamp 기준으로 정렬할 때, timeStamp가 null일 수도 있다는 점 고려하기
    - [x]  친구가 없는 상태에서 친구 추가 시 채팅 UI가 바로 친구가 추가된 UI으로 반영되지 않는다.
    - [x]  active state가 반영되지 않음 → 백엔드 수정하면 될듯
- 차단
    - [x]  차단 시 상대방측에서 즉시 친구삭제가 되지 않는다. →백엔드에서 수정해야함
    - [ ]  ~~차단한 유저가 친구 요청 시, 차단 해제 후 친구요청에 반영되지 않는다.~~
        - ~~차단 후 정상적인 처리가 안됨~~
        - ~~my 오해인듯~~
- 친구관리페이지
    - resize할때 매우 느리게 적용됨
        - 채팅데이터가 매우 많으면 나타나는 현상임
        - 채팅메시지의 길이를 제한해야할듯!